### PR TITLE
Fix hotel_rop link for new post

### DIFF
--- a/content/posts/dctf-2021-hotel-rop-ret2libc-pie.md
+++ b/content/posts/dctf-2021-hotel-rop-ret2libc-pie.md
@@ -17,7 +17,7 @@ Today, we will be looking at a pwn challenge from **dCTF 2021** which features r
 ---
 > They say programmers' dream is California. And because they need somewhere to stay, we've built a hotel!
 >
-> Attachments: [hotel_rop](/content/files/hotel_rop)
+> Attachments: [hotel_rop](/files/hotel_rop)
 
 <br>
 


### PR DESCRIPTION
I figured that the file was actually in `/files/hotel_rop` instead of `/content/files/hotel_rop`, not sure why it works but it shouldn't be any problem. 

Tested on the currently officially deployed hugo site.